### PR TITLE
Utilize the singleton pattern to replace new-ing a BroadcastChannel each time.

### DIFF
--- a/src/components/BindCast.ts
+++ b/src/components/BindCast.ts
@@ -10,8 +10,13 @@ class BroadcastChannelManager {
 
   private readonly channel: BroadcastChannel;
 
+  private readonly callbacks: Record<string, Function> = {};
+
   private constructor() {
     this.channel = new BroadcastChannel("cross_page_binding");
+    this.channel.onmessage = (event: MessageEvent<MessageData>) => {
+      this.callbacks[event.data.fieldKey]?.(event.data);
+    };
   }
 
   public static getInstance(): BroadcastChannelManager {
@@ -21,10 +26,11 @@ class BroadcastChannelManager {
     return BroadcastChannelManager.instance;
   }
 
-  public getMessage<MessageData>(callback: (data: MessageData) => void): void {
-    this.channel.onmessage = (event: MessageEvent<MessageData>) => {
-      callback(event.data);
-    };
+  public getMessage<MessageData>(
+    callback: (data: MessageData) => void,
+    fieldKey: string
+  ): void {
+    this.callbacks[fieldKey] = this.callbacks[fieldKey] || callback;
   }
 
   public postMessage<MessageData>(data: MessageData): void {
@@ -36,26 +42,22 @@ class BroadcastChannelManager {
   }
 }
 
-export function binding<T>(val: Ref<T>): (fieldKey: string) => Ref<T> {
-  return function useBinding(fieldKey: string): Ref<T> {
-    const manager = BroadcastChannelManager.getInstance();
+export function binding<T>(val: Ref<T>, fieldKey: string): Ref<T> {
+  const manager = BroadcastChannelManager.getInstance();
 
-    manager.getMessage((data: MessageData) => {
-      console.debug("getMessage", data, fieldKey);
-      if (data.fieldKey === fieldKey) {
-        val.value = data.value as T;
-      }
-    });
+  manager.getMessage<MessageData>((data) => {
+    if (data.fieldKey === fieldKey) {
+      val.value = data.value as T;
+    }
+  }, fieldKey);
 
-    return computed<T>({
-      get: () => val.value,
-      set: (value: T) => {
-        val.value = value;
-        console.debug("fieldKey", fieldKey);
-        manager.postMessage({ fieldKey, value });
-      },
-    });
-  };
+  return computed<T>({
+    get: () => val.value,
+    set: (value: T) => {
+      val.value = value;
+      manager.postMessage({ fieldKey, value });
+    },
+  });
 }
 
 export function closeBroadcastChannel(): void {

--- a/src/components/BindCast.ts
+++ b/src/components/BindCast.ts
@@ -1,18 +1,64 @@
-import { Ref, computed } from "vue"
+import { Ref, computed } from "vue";
 
-export function binding<T>(val: Ref<T>, id: string) {
-  const channel = new BroadcastChannel('cross_page_binding_' + id);
-  channel.onmessage = (messageEvent: MessageEvent<T>) => {
-    val.value = messageEvent.data
+interface MessageData {
+  fieldKey: string;
+  value: unknown;
+}
+
+class BroadcastChannelManager {
+  private static instance: BroadcastChannelManager;
+
+  private readonly channel: BroadcastChannel;
+
+  private constructor() {
+    this.channel = new BroadcastChannel("cross_page_binding");
   }
-  channel.postMessage(val.value)
-  return computed<T>({
-    get: () => {
-      return val.value
-    },
-    set: (newVal: T) => {
-      val.value = newVal
-      channel.postMessage(newVal)
+
+  public static getInstance(): BroadcastChannelManager {
+    if (!BroadcastChannelManager.instance) {
+      BroadcastChannelManager.instance = new BroadcastChannelManager();
     }
-  })
+    return BroadcastChannelManager.instance;
+  }
+
+  public getMessage<MessageData>(callback: (data: MessageData) => void): void {
+    this.channel.onmessage = (event: MessageEvent<MessageData>) => {
+      callback(event.data);
+    };
+  }
+
+  public postMessage<MessageData>(data: MessageData): void {
+    this.channel.postMessage(data);
+  }
+
+  public close(): void {
+    this.channel.close();
+  }
+}
+
+export function binding<T>(val: Ref<T>): (fieldKey: string) => Ref<T> {
+  return function useBinding(fieldKey: string): Ref<T> {
+    const manager = BroadcastChannelManager.getInstance();
+
+    manager.getMessage((data: MessageData) => {
+      console.debug("getMessage", data, fieldKey);
+      if (data.fieldKey === fieldKey) {
+        val.value = data.value as T;
+      }
+    });
+
+    return computed<T>({
+      get: () => val.value,
+      set: (value: T) => {
+        val.value = value;
+        console.debug("fieldKey", fieldKey);
+        manager.postMessage({ fieldKey, value });
+      },
+    });
+  };
+}
+
+export function closeBroadcastChannel(): void {
+  const manager = BroadcastChannelManager.getInstance();
+  manager.close();
 }

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
-import { ref } from 'vue'
-import { binding } from './BindCast'
+import { ref, onBeforeUnmount } from 'vue'
+import { binding,closeBroadcastChannel } from './BindCast'
 
 defineProps<{ msg: string }>()
 
-//const count = ref(0)
-//const countBind = binding(count, 'count')
-const countBind = binding(ref(0), 'count')
+const count = ref(0)
+const countBind = binding(count)("count")
+const anotherCount = ref(99)
+const anotherCountBind = binding(anotherCount)("anotherCount")
+
+onBeforeUnmount(() => {
+  closeBroadcastChannel()
+})
 
 </script>
 
@@ -15,6 +20,7 @@ const countBind = binding(ref(0), 'count')
 
   <div class="card">
     <button type="button" @click="countBind++">count is {{ countBind }}</button>
+    <button type="button" @click="anotherCountBind++">anotherCount is {{ anotherCountBind }}</button>
     <p>
       Edit
       <code>components/HelloWorld.vue</code> to test HMR

--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -5,9 +5,9 @@ import { binding,closeBroadcastChannel } from './BindCast'
 defineProps<{ msg: string }>()
 
 const count = ref(0)
-const countBind = binding(count)("count")
+const countBind = binding(count, "count")
 const anotherCount = ref(99)
-const anotherCountBind = binding(anotherCount)("anotherCount")
+const anotherCountBind = binding(anotherCount, "anotherCount")
 
 onBeforeUnmount(() => {
   closeBroadcastChannel()


### PR DESCRIPTION
原来的实现当中如果存在n个想双向绑定的变量，则相应地需要传入n个id以及创建n个`BroadcastChannel`。这一版实现中，传入fieldKey区分不同的变量，并且使用单例模式保证只用同一个连接，而且不需要无意义的id字段了。

不过虽然想法是这样的，我这个实现上还是有问题，所以探讨一下是哪里出问题了，目前定位到的可能是多次binding后，getMessage的回调中的fieldKey总是最后一次调用binding函数传入的fieldKey，不知道是为什么